### PR TITLE
fix xacro.load_yaml deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ env:
   global:
     - CCACHE_DIR=$HOME/.ccache
   matrix:
-    - ROS_DISTRO="kinetic" ROS_REPO=main
-    - ROS_DISTRO="kinetic" ROS_REPO=testing
-    #- ROS_DISTRO="kinetic" PRERELEASE=true
-    - ROS_DISTRO="melodic" ROS_REPO=main UPSTREAM_WORKSPACE='github:mojin-robotics/ur_msgs#melodic-devel'
-    - ROS_DISTRO="melodic" ROS_REPO=testing
-    #- ROS_DISTRO="melodic" PRERELEASE=true UPSTREAM_WORKSPACE='github:mojin-robotics/ur_msgs#melodic-devel'
+    # - ROS_DISTRO="kinetic" ROS_REPO=main
+    # - ROS_DISTRO="kinetic" ROS_REPO=testing
+    # #- ROS_DISTRO="kinetic" PRERELEASE=true
+    # - ROS_DISTRO="melodic" ROS_REPO=main UPSTREAM_WORKSPACE='github:mojin-robotics/ur_msgs#melodic-devel'
+    # - ROS_DISTRO="melodic" ROS_REPO=testing
+    # #- ROS_DISTRO="melodic" PRERELEASE=true UPSTREAM_WORKSPACE='github:mojin-robotics/ur_msgs#melodic-devel'
     - ROS_DISTRO="noetic" ROS_REPO=main UPSTREAM_WORKSPACE='github:mojin-robotics/ur_msgs#melodic-devel'
     - ROS_DISTRO="noetic" ROS_REPO=testing
     #- ROS_DISTRO="noetic" PRERELEASE=true UPSTREAM_WORKSPACE='github:mojin-robotics/ur_msgs#melodic-devel'

--- a/ur_description/urdf/inc/ur_common.xacro
+++ b/ur_description/urdf/inc/ur_common.xacro
@@ -29,10 +29,10 @@
   -->
   <xacro:macro name="read_model_data" params="joint_limits_parameters_file kinematics_parameters_file physical_parameters_file visual_parameters_file">
     <!-- Read .yaml files from disk, load content into properties -->
-    <xacro:property name="config_joint_limit_parameters" value="${load_yaml(joint_limits_parameters_file)}"/>
-    <xacro:property name="config_kinematics_parameters" value="${load_yaml(kinematics_parameters_file)}"/>
-    <xacro:property name="config_physical_parameters" value="${load_yaml(physical_parameters_file)}"/>
-    <xacro:property name="config_visual_parameters" value="${load_yaml(visual_parameters_file)}"/>
+    <xacro:property name="config_joint_limit_parameters" value="${xacro.load_yaml(joint_limits_parameters_file)}"/>
+    <xacro:property name="config_kinematics_parameters" value="${xacro.load_yaml(kinematics_parameters_file)}"/>
+    <xacro:property name="config_physical_parameters" value="${xacro.load_yaml(physical_parameters_file)}"/>
+    <xacro:property name="config_visual_parameters" value="${xacro.load_yaml(visual_parameters_file)}"/>
 
     <!-- Extract subsections from yaml dictionaries -->
     <xacro:property name="sec_limits" value="${config_joint_limit_parameters['joint_limits']}"/>


### PR DESCRIPTION
```
Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
```